### PR TITLE
Fix deprecated use of cargo build directive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,4 @@
 name = "lua"
 version = "0.1.0"
 authors = [ "kevin@sb.org" ]
-build = "make cargo-prep"
+build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::io::Command;
+
+fn main() {
+    match Command::new("make").arg("cargo-prep").spawn() {
+        Ok(p) => p,
+        Err(e) => panic!("failed to build config.rs: {}", e),
+    };
+}


### PR DESCRIPTION
- new build.rs just calls make (importing header files did not seem
  straight-forward)

Fix for part of #14 

It would be nice to get rid of `config.c`, but I suppose if header files could already be easily included in Rust, it wouldn't need to be there in the first place.
