### PR TITLE
Fix for latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub fn upvalueindex(n: i32) -> i32 {
     raw::lua_upvalueindex(n as c_int) as i32
 }
 
-include!(concat!(env!("OUT_DIR"), "/config.rs"))
+include!(concat!(env!("OUT_DIR"), "/config.rs"));
 
 #[allow(missing_docs)]
 pub mod raw;
@@ -2900,7 +2900,7 @@ impl<'l> RawState<'l> {
         }
         lstv.push(ptr::null());
         let i = aux::raw::luaL_checkoption(self.L, narg as c_int, defp, lstv.as_ptr()) as uint;
-        lst[i].ref1()
+        & lst[i].1
     }
 
     pub unsafe fn ref_(&mut self, t: i32) -> i32 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,8 +4,10 @@ use Type;
 use raw;
 
 use libc;
-use std::task;
+use std::thread::Thread;
 use std::any::AnyRefExt;
+use std::any::Any;
+use std::sync::Arc;
 
 #[test]
 fn test_state_init() {
@@ -22,10 +24,10 @@ fn test_error() {
 
 #[test]
 fn test_errorstr() {
-    let res = task::try::<()>(proc() {
+    let res : Result<(), Box<Any + Send>>  = Thread::spawn(move || {
         let mut s = State::new();
         s.errorstr("some err");
-    });
+    }).join(); 
     let err = res.unwrap_err();
     let expected = "unprotected error in call to Lua API (some err)";
     let s = err.downcast_ref::<String>();
@@ -93,16 +95,19 @@ fn test_checkoption() {
     }
     assert_eq!(*s.checkoption(1, Some("three"), &lst), CheckOptionEnum::Three);
 
-    let res = task::try(proc() {
+    let lst_arc1 = Arc::new(lst);
+    let lst_arc2 = lst_arc1.clone();
+        
+    let res = Thread::spawn(move || {
         let mut s = State::new();
-        s.checkoption(1, None, &lst);
-    });
+        s.checkoption(1, None, &*lst_arc1);
+    }).join();
     assert!(res.is_err(), "expected error from checkoption");
-
-    let res = task::try(proc() {
+   
+    let res = Thread::spawn(move || {
         let mut s = State::new();
-        s.checkoption(1, Some("four"), &lst);
-    });
+        s.checkoption(1, Some("four"), &*lst_arc2);
+    }).join();
     assert!(res.is_err(), "expected error from checkoption");
 }
 


### PR DESCRIPTION
lib.rs:
Fix for changes to macros, and tuple indexing.

tests.rs:
Fix for language removal of proc, replaced with move.
Replaced depreciated std::task with std::thread
