### PR TITLE
Fix for rust nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,14 @@
 [root]
 name = "lua"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.9"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![allow(non_snake_case)]
 #![allow(trivial_numeric_casts)] // FIXME: rust-lang/rfcs#1020
 #![feature(unicode)]
-#![feature(unsafe_no_drop_flag,filling_drop)]
 
 extern crate libc;
 
@@ -244,7 +243,6 @@ impl fmt::Debug for PCallError {
 ///
 /// Note that it is completely unsafe to pass a reference to State to a
 /// function that is executing in a protected scope. Use ExternState for that.
-#[unsafe_no_drop_flag]
 #[repr(C)]
 pub struct State {
     L: *mut raw::lua_State,
@@ -254,7 +252,7 @@ pub struct State {
 
 impl Drop for State {
     fn drop(&mut self) {
-        if !self.L.is_null() && self.L as usize != mem::POST_DROP_USIZE {
+        if !self.L.is_null() {
             unsafe {
                 raw::lua_close(self.L);
             }


### PR DESCRIPTION
The package is currently breaking on nightly. This PR causes tests to pass, however I'm unsure if it is correct - especially regarding the removal `POST_DROP_USIZE` as I can't find much info about it online.

For context, I'm basing this change off of what I saw [on servo to support nightly](https://github.com/servo/servo/commit/c66380d83c828fc36b6670b4dfb3126c76d6b822), which appears to likewise remove similar logic.
