### PR TITLE
Removed outdated feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(non_snake_case)]
 #![allow(trivial_numeric_casts)] // FIXME: rust-lang/rfcs#1020
 #![feature(unicode)]
-#![feature(unsafe_no_drop_flag,filling_drop)]
+#![feature(filling_drop)]
 
 extern crate libc;
 


### PR DESCRIPTION
The feature `unsafe_no_drop_flag` has been removed, since drop flags are now handled on the stack.